### PR TITLE
Generate nonces with cryptographically secure PRNG

### DIFF
--- a/lib/Service/TwitterAPIService.php
+++ b/lib/Service/TwitterAPIService.php
@@ -267,11 +267,9 @@ class TwitterAPIService {
 		$url = 'https://api.twitter.com/' . $apiVersion . '/' . $endPoint;
 
 		$ts = (new \Datetime())->getTimestamp();
-		$permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-		$nonce = substr(str_shuffle($permitted_chars), 0, 32);
 		$headerParams = [
 			'oauth_consumer_key' => $consumerKey,
-			'oauth_nonce' => base64_encode($nonce),
+			'oauth_nonce' => $this->makeNonce(),
 			'oauth_signature_method' => 'HMAC-SHA1',
 			'oauth_timestamp' => $ts,
 			'oauth_token' => $oauthToken,
@@ -329,11 +327,9 @@ class TwitterAPIService {
 		$url = 'https://api.twitter.com/oauth/request_token';
 
 		$ts = (new \Datetime())->getTimestamp();
-		$permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-		$nonce = substr(str_shuffle($permitted_chars), 0, 32);
 		$headerParams = [
 			'oauth_consumer_key' => $consumerKey,
-			'oauth_nonce' => base64_encode($nonce),
+			'oauth_nonce' => $this->makeNonce(),
 			'oauth_signature_method' => 'HMAC-SHA1',
 			'oauth_timestamp' => $ts,
 			'oauth_version' => '1.0',
@@ -393,11 +389,9 @@ class TwitterAPIService {
 		$url = 'https://api.twitter.com/oauth/access_token';
 
 		$ts = (new \Datetime())->getTimestamp();
-		$permitted_chars = '0123456789abcdefghijklmnopqrstuvwxyz';
-		$nonce = substr(str_shuffle($permitted_chars), 0, 32);
 		$headerParams = [
 			'oauth_consumer_key' => $consumerKey,
-			'oauth_nonce' => base64_encode($nonce),
+			'oauth_nonce' => $this->makeNonce(),
 			'oauth_signature_method' => 'HMAC-SHA1',
 			'oauth_timestamp' => $ts,
 			'oauth_token' => $oauthToken,
@@ -492,5 +486,19 @@ class TwitterAPIService {
 			$this->logger->warning('Twitter request error : '.$e->getMessage(), array('app' => $this->appName));
 			return ['error' => $e->getMessage()];
 		}
+	}
+
+	private function makeNonce(): string {
+		$len = 32;
+		$buf = '';
+		$permittedChars = '0123456789abcdefghijklmnopqrstuvwxyz';
+		$maxBound = strlen($permittedChars) - 1;
+
+		while ($len-- > 0) {
+			$choice = random_int(0, $maxBound);
+			$buf .= $permittedChars[$choice];
+		}
+
+		return $buf;
 	}
 }


### PR DESCRIPTION
The `str_shuffle()` uses the Mersenne Twister (as of PHP 7.1) random number generator, which is predictable.

Since the whole point of nonces is to be a value that is not predictable (and only to be used once), Mersenne Twister is unsuitable for this task.

We now generate the nonce using random_int() and only emit characters of the alphabet we previously had in $permitted_chars. Since I'm not the author of the original code, I can only assume that the author wanted to use this as the alphabet even though the value is run through base64_encode() again.

**Note:** I stumbled on this while reviewing the source code diff between all Nextcloud 19 and Nextcloud 20 apps. This change is entirely **untested** (I don't even have a Twitter account).

Cc: @eneiluj